### PR TITLE
Edit view for list events nearby

### DIFF
--- a/app/src/main/java/com/app/concertbud/concertbuddies/Adapters/EventsAdapter.java
+++ b/app/src/main/java/com/app/concertbud/concertbuddies/Adapters/EventsAdapter.java
@@ -22,7 +22,6 @@ public class EventsAdapter extends RecyclerView.Adapter<EventViewHolder> {
     private OnEventClickListener listener;
 
     /* Get a list of events */
-    //TODO: ArrayList
     ArrayList<EventsEntity> mConcertsList;
 
     public EventsAdapter(Context context, OnEventClickListener listener, ArrayList<EventsEntity> concerts) {
@@ -53,6 +52,6 @@ public class EventsAdapter extends RecyclerView.Adapter<EventViewHolder> {
 
     @Override
     public int getItemCount() {
-        return 20;
+        return mConcertsList.size();
     }
 }

--- a/app/src/main/java/com/app/concertbud/concertbuddies/Networking/Services/TicketMasterServices.java
+++ b/app/src/main/java/com/app/concertbud/concertbuddies/Networking/Services/TicketMasterServices.java
@@ -12,6 +12,9 @@ import retrofit2.http.Query;
 
 public interface TicketMasterServices {
     @GET("/discovery/v2/events.json")
-    Call<CompleteTMConcertsResponse> getConcertsNearby(@Query("geoPoint") String geo_point,
+    Call<CompleteTMConcertsResponse> getConcertsNearby(@Query("radius") int radius,
+                                                       @Query("geoPoint") String geo_point,
+                                                       @Query("sort") String sort_option,
+                                                       @Query("segmentName") String segment,
                                                        @Query("apikey") String api_key);
 }

--- a/app/src/main/java/com/app/concertbud/concertbuddies/Tasks/Configs/Jobs/FetchNearbyConcertsJob.java
+++ b/app/src/main/java/com/app/concertbud/concertbuddies/Tasks/Configs/Jobs/FetchNearbyConcertsJob.java
@@ -33,6 +33,9 @@ public class FetchNearbyConcertsJob extends Job {
 
     /* User's Location information */
     private String queryLocation;
+    private int DEFAULT_RADIUS = 50;
+    private String DEFAULT_SEGMENT = "Music";
+    private String DEFAULT_SORT_OPTION = "date,asc";
 
     public FetchNearbyConcertsJob(int pageNum, double lng, double lat) {
         super(new Params(JobPriority.HIGH).requireNetwork().persist().groupBy(JobGroup.concert));
@@ -42,7 +45,8 @@ public class FetchNearbyConcertsJob extends Job {
     @Override
     public void onRun() throws Throwable {
         TicketMasterServices service = TicketMasterContext.instance.create(TicketMasterServices.class);
-        service.getConcertsNearby(queryLocation, getApplicationContext().getString(R.string.ticket_master_api_token))
+        service.getConcertsNearby(DEFAULT_RADIUS, queryLocation, DEFAULT_SORT_OPTION,
+                DEFAULT_SEGMENT, getApplicationContext().getString(R.string.ticket_master_api_token))
                 .enqueue(new Callback<CompleteTMConcertsResponse>() {
                     @Override
                     public void onResponse(Call<CompleteTMConcertsResponse> call, Response<CompleteTMConcertsResponse> response) {

--- a/app/src/main/java/com/app/concertbud/concertbuddies/ViewFragments/ListSearchEventFragment.java
+++ b/app/src/main/java/com/app/concertbud/concertbuddies/ViewFragments/ListSearchEventFragment.java
@@ -26,6 +26,8 @@ import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -37,8 +39,12 @@ public class ListSearchEventFragment extends Fragment implements OnEventClickLis
     private EventsAdapter eventsAdapter;
     private Unbinder unbinder;
 
+    /* HashMap of all Nearby Concerts */
+    private HashMap<String, EventsEntity> mConcertsHashMap = new HashMap<>();
     /* Array List of all Nearby Concerts */
-    ArrayList<EventsEntity> mConcertsList = new ArrayList<>();
+    private ArrayList<EventsEntity> mConcertsList = new ArrayList<>();
+
+    private int mPosition;
 
     public ListSearchEventFragment() {
         // Required empty public constructor
@@ -56,7 +62,7 @@ public class ListSearchEventFragment extends Fragment implements OnEventClickLis
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (getArguments() != null) {
-            // TODO: initialize local position here ??
+            mPosition = getArguments().getInt("page_position");
         }
 
     }
@@ -126,11 +132,12 @@ public class ListSearchEventFragment extends Fragment implements OnEventClickLis
 
     @Subscribe(sticky = true, threadMode = ThreadMode.MAIN)
     public void onEvent(ConcertsNearbyBus bus) {
-        // update adapter
+        /* Put all events in HashMap to make sure no duplicated event is allowed */
         for (int i = 0; i < bus.getConcerts().size(); i++) {
-            mConcertsList.add(bus.getConcerts().get(i));
+            mConcertsHashMap.put(bus.getConcerts().get(i).getName(), bus.getConcerts().get(i));
         }
-        eventsAdapter.notifyItemChanged(1);
+        mConcertsList.addAll(mConcertsHashMap.values());
+        eventsAdapter.notifyItemChanged(mPosition);
         EventBus.getDefault().removeStickyEvent(bus);
     }
 }

--- a/app/src/main/java/com/app/concertbud/concertbuddies/ViewHolders/EventViewHolder.java
+++ b/app/src/main/java/com/app/concertbud/concertbuddies/ViewHolders/EventViewHolder.java
@@ -51,7 +51,18 @@ public class EventViewHolder extends RecyclerView.ViewHolder {
         unbinder = ButterKnife.bind(this, itemView);
 
         // Get Event Image
-        ImageLoader.loadAdjustImageFromURL(mEventImage, concert.getImages().get(0).getUrl(), mEventProgress);
+        // Only choose one whose width is 500px or larger
+        boolean edited = false;
+        for (int i = 0; i < concert.getImages().size(); i++) {
+            if (concert.getImages().get(i).getWidth() > 500) {
+                ImageLoader.loadAdjustImageFromURL(mEventImage, concert.getImages().get(i).getUrl(), mEventProgress);
+                edited = true;
+                break;
+            }
+        }
+        if (!edited) {
+            ImageLoader.loadAdjustImageFromURL(mEventImage, concert.getImages().get(0).getUrl(), mEventProgress);
+        }
         // Get Event Name
         mEventName.setText(concert.getName());
         // Get Date
@@ -72,7 +83,7 @@ public class EventViewHolder extends RecyclerView.ViewHolder {
 
         // Get Distance
         Double distance = concert.getDistance();
-        mRideDistance.setText(Double.toString(distance) + " miles");
+        mRideDistance.setText(Long.toString(Math.round(distance)) + " miles");
     }
 
     public void onRecycled() {


### PR DESCRIPTION
Make sure HD images for events are displayed and no duplicated event is allowed.
Added default radius for events nearby to be 50 miles. Events are sorted by time in ascending order.